### PR TITLE
Add support for array query parameters on GET requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,8 @@ function EXPA(username, password, enforceSSL){
 	var r = request.defaults({
 		rejectUnauthorized: typeof enforceSSL !== 'boolean' ? true : enforceSSL,
 		jar: true,
-		followAllRedirects: true
+		followAllRedirects: true,
+		qsStringifyOptions: {arrayFormat: 'brackets'}
 	});
 
 	var _ = {},


### PR DESCRIPTION
Hey AIESEC!
First of all, thank you for creating this most excellent module. 

The problem I identified while using it was that, when defining the parameters that go into data on _.get = function(url, data) , if I want one of them to be an array (in my case I wanted 'filters[programmes]':[1, 2, 5] to get information from GV, GT and GE in the same query), this array would be improperly processed by the request module, and therefore EXPA would give an error response. This fix makes sure that the qs.stringify() function that request uses to serialize objects into querystrings does it in a format that EXPA recognizes

I hope it helps